### PR TITLE
Add filter options for project pagination

### DIFF
--- a/src/cloud/iotile-cloud-serv.ts
+++ b/src/cloud/iotile-cloud-serv.ts
@@ -294,9 +294,9 @@ export class IOTileCloud {
    *
    * Returns an array of OrgMetaData objects with all organizations retrieved.
    */
-  public async fetchOrgMetaData() : Promise<OrgMetaData[]>{
+  public async fetchOrgMetaData(filter?: ApiFilter) : Promise<OrgMetaData[]>{
     let orgs = await this.fetchOrgs();
-    let projects = await this.fetchProjects();
+    let projects = await this.fetchProjects(filter);
 
     let projectMap: {[key: string]: Project} = {};
     let orgMap : {[key: string]: OrgMetaData} = {};

--- a/src/cloud/iotile-cloud-serv.ts
+++ b/src/cloud/iotile-cloud-serv.ts
@@ -294,9 +294,9 @@ export class IOTileCloud {
    *
    * Returns an array of OrgMetaData objects with all organizations retrieved.
    */
-  public async fetchOrgMetaData(filter?: ApiFilter) : Promise<OrgMetaData[]>{
+  public async fetchOrgMetaData(projectFilter?: ApiFilter) : Promise<OrgMetaData[]>{
     let orgs = await this.fetchOrgs();
-    let projects = await this.fetchProjects(filter);
+    let projects = await this.fetchProjects(projectFilter);
 
     let projectMap: {[key: string]: Project} = {};
     let orgMap : {[key: string]: OrgMetaData} = {};


### PR DESCRIPTION
Allow filters to be passed in to while getting projects in fetchOrgMetaData. Currently fetchProjects accepts filters, but since fetchOrgMetaData makes a private call to the fetchProjects method in the package, users can't pass in the project filters during that call, which yields inconsistent results in cloud syncs. 

See https://github.com/iotile/iotile-mobile-ionic/issues/1130