### PR TITLE
Move iotile-common to peer dependency

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # Release Notes for @iotile/iotile-cloud
 
+## 0.0.14
+
+- Move @iotile/iotile-common to an external peer dependency so that we only have a single
+  copy of it in projects that include both @iotile/iotile-device and @iotile/iotile-common
+
 ## v0.0.13
 
 - Move to use `typescript-logging` for all logging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iotile/iotile-cloud",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,6 +28,7 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@iotile/iotile-common/-/iotile-common-0.0.12.tgz",
       "integrity": "sha512-/5CbIWSElex6qCAMflRxOb6Hjlg7ZquFg4ChtheCMaZbM2V3yxrULKkluVxyl/8C3zKxkMu+mFVk003sXXX74g==",
+      "dev": true,
       "requires": {
         "crypto-js": "^3.1.9-1",
         "sha.js": "^2.4.10"
@@ -1702,7 +1703,8 @@
     "crypto-js": {
       "version": "3.1.9-1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
+      "dev": true
     },
     "cssom": {
       "version": "0.3.2",
@@ -3396,7 +3398,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -5737,7 +5740,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6102,8 +6106,9 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iotile/iotile-cloud",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A typescript library for interfacing with the IOTile Cloud API",
   "main": "dist/iotile-cloud.umd.js",
   "types": "dist/types/index.d.ts",
@@ -72,14 +72,15 @@
   "dependencies": {
     "axios": "^0.18.0",
     "axios-mock-adapter": "^1.15.0",
-    "@iotile/iotile-common": "0.0.12",
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.1"
   },
   "peerDependencies": {
+    "@iotile/iotile-common": "0.0.12",
     "typescript-logging": "^0.6.3"
   },
   "devDependencies": {
+    "@iotile/iotile-common": "0.0.12",
     "@types/jest": "^22.0.0",
     "@types/node": "^9.3.0",
     "cz-conventional-changelog": "^2.1.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -16,7 +16,7 @@ export default {
   ],
   sourcemap: true,
   // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
-  external: ['typescript-logging'],
+  external: ['typescript-logging', "@iotile/iotile-common"],
   watch: {
     include: 'src/**',
   },


### PR DESCRIPTION
This is necessary to ensure that there is only one copy of `@iotile/iotile-common` in `iotile-mobile-ionic` due to issues with webpack discovering the duplicate code imported from iotile-device and iotile-cloud and coalescing them into a single chunk.  

The result of not doing this is that typescript logging breaks because the same category gets declared multiple times (once when importing iotile-cloud and again when importing iotile-device).